### PR TITLE
[機能追加] 同期誤差ベースライン測定用の計測専用ファーム drift_measure.ino

### DIFF
--- a/sync/arduino/drift_measure/drift_measure.ino
+++ b/sync/arduino/drift_measure/drift_measure.ino
@@ -1,0 +1,108 @@
+// drift_measure.ino
+// 同期誤差(SYNCタイミング誤差)のベースライン測定用 計測専用ファーム
+// ─────────────────────────────────────────────────────────────
+// 役割:
+//   - I2Cで master からの SYNC(0x01) を受信するだけ
+//   - 連続する SYNC の受信間隔を測り、公称小節長との差(drift)を
+//     ASCIIのCSVで Serial に1行ずつ出力する
+//   - 音は鳴らさない / バイナリパケットも送らない
+//     → 音符ストリームに 0xAA が混入してパーサが壊れる問題が原理的に起きない
+//
+// 使い方:
+//   1. 下の MY_I2C_ADDRESS を測定するボードに合わせて変更して書き込む
+//        flute=0x10 / clarinet=0x11 / organ=0x12 / drum=0x13
+//   2. master は本番の sync/arduino/master/master.ino をそのまま使う
+//   3. シリアルモニタ(115200)で目視、または端末で CSV にリダイレクトして収集
+//        例(mac): cat /dev/cu.usbmodemXXXX > flute_drift.csv
+//
+// 出力フォーマット(CSV):
+//   addr,bar,interval_us,drift_us
+//     addr        : 自分のI2Cアドレス(16進)
+//     bar         : master から来た global_bar
+//     interval_us : 直前のSYNCからの実測間隔(µs, 自分のmicros()基準)
+//     drift_us    : interval_us - 公称小節長 = この小節のタイミング誤差(µs)
+//                   +なら遅い側 / -なら速い側
+//                   drift_us が +2,000,000 付近 = SYNCを1回取りこぼしたサイン
+//
+// 測れる範囲: 各スレーブの「小節ごとのタイミング誤差(ジッタ＋masterに対する
+//             クロックドリフト)」。
+// 測れない範囲: 楽器間の絶対スキュー(I2C逐次配信の一定ズレは前後差で相殺される)。
+//             それは共通クロックが要るので別途(監視Arduino/オシロ)。
+// ─────────────────────────────────────────────────────────────
+
+#include <Wire.h>
+
+// ─── I2Cアドレス(★ボードごとに変更)───────────────────────────
+#define MY_I2C_ADDRESS 0x10   // flute=0x10 / clarinet=0x11 / organ=0x12 / drum=0x13
+
+// ─── I2Cコマンド定数(master/本番slaveと同一)─────────────────
+const byte CMD_SYNC = 0x01;
+
+// ─── I2C受信バッファ(ISRと共有するのでvolatile)─────────────
+volatile bool          newData  = false;
+volatile uint16_t      rxBar    = 0;
+volatile uint16_t      rxBpmX10 = 0;
+volatile unsigned long rxTimeUs = 0;
+
+// ─── 測定状態 ─────────────────────────────────────────────────
+unsigned long prevRxUs = 0;
+bool          havePrev = false;
+
+// ─── setup() ──────────────────────────────────────────────────
+void setup() {
+  Serial.begin(115200);
+  Wire.begin(MY_I2C_ADDRESS);
+  Wire.onReceive(receiveEvent);
+  Serial.println(F("addr,bar,interval_us,drift_us"));  // CSVヘッダ
+}
+
+// ─── loop() ───────────────────────────────────────────────────
+void loop() {
+  if (newData) {
+    noInterrupts();
+    unsigned long t   = rxTimeUs;
+    uint16_t      bar = rxBar;
+    uint16_t      bpm = rxBpmX10;
+    newData = false;
+    interrupts();
+
+    if (havePrev) {
+      long interval = (long)(t - prevRxUs);   // 符号付き差分でoverflow安全
+      long nominal  = (long)calcBarUs(bpm);
+      long drift    = interval - nominal;     // 小節ごとのタイミング誤差(µs)
+
+      Serial.print(MY_I2C_ADDRESS, HEX); Serial.print(',');
+      Serial.print(bar);                 Serial.print(',');
+      Serial.print(interval);            Serial.print(',');
+      Serial.println(drift);
+    }
+
+    prevRxUs = t;
+    havePrev = true;
+  }
+}
+
+// ─── I2C受信イベント(ISR内なのでSerial.print禁止)───────────
+void receiveEvent(int howMany) {
+  if (howMany < 1) return;
+  byte cmd = Wire.read();
+
+  if (cmd == CMD_SYNC && howMany == 5) {
+    byte barH = Wire.read(), barL = Wire.read();
+    byte bpmH = Wire.read(), bpmL = Wire.read();
+    rxBar    = ((uint16_t)barH << 8) | barL;
+    rxBpmX10 = ((uint16_t)bpmH << 8) | bpmL;
+    rxTimeUs = micros();   // ※ISR内micros()の癖で稀に~1msぶれる=ノイズ床
+    newData  = true;
+  }
+  else {
+    // SYNC以外(START/CONFIG等)は測定に不要なので読み捨て
+    while (Wire.available()) Wire.read();
+  }
+}
+
+// ─── ユーティリティ:BPM×10 → 1小節の長さ(µs)──────────────
+unsigned long calcBarUs(uint16_t bpm_x10) {
+  if (bpm_x10 == 0) return 2000000UL;
+  return 60000000UL * 4UL * 10UL / bpm_x10;
+}


### PR DESCRIPTION
## 概要
Arduino間(master ↔ 各楽器slave)の同期誤差を、**PLLなしの素の状態でベースライン測定**するための計測専用ファームを追加します。新規1ファイルのみ・**既存コードは無変更**(master・本番slave・本番pdeは無改造)。
**音は鳴りません。**「ズレ(drift)」の数字をシリアルにCSVで出すだけです。

## なぜ作ったか
以前の測定方法(`feature/sync-drift`)は、ズレの数字を**音符と同じ通信線にバイナリで混ぜて**送っていました。その数字に通信の区切り記号(`0xAA`)と同じ値が混ざると、受信側(`.pde`)が音符を読み間違えて**演奏のリズムや音の長さが狂う**問題がありました。本番の音符はたまたま `0xAA` が出ないので壊れていなかっただけです。
このツールは**音を出さず、人が読めるテキスト(CSV)だけ**を出すので、その問題が原理的に起きません。

---

## 使い方(この順でやればOK)

### ① ブランチを取得
```
git fetch
git checkout feature/drift-measure
```

### ② 各スレーブに測定用スケッチを書き込む
`sync/arduino/drift_measure/drift_measure.ino` を Arduino IDE で開き、上のほうの **`#define MY_I2C_ADDRESS 0x10`** の数字を、そのボードに合わせて変えて書き込む(1台ずつ):

| 楽器 | 書く数字 |
|------|---------|
| フルート | `0x10` |
| クラリネット | `0x11` |
| オルガン | `0x12` |
| ドラム | `0x13` |

### ③ master はいつものを書き込む
`sync/arduino/master/master.ino` を master 機に。**改造不要。**

### ④ 全部つないで電源ON
I2C(SDA・SCL・**GND全部つなぐ**・プルアップ)+ USB。

### ⑤ 数字を見る
Arduino IDE の**シリアルモニタ**(右下のボーレートを **115200** に!)。だいたい2秒に1行こう流れたら成功:
```
addr,bar,interval_us,drift_us
10,1,2000041,41
10,2,1999987,-13
10,3,2000005,5
```

> ファイルに保存するときは `cat` だと速度設定されず化けます。**シリアルモニタの文字をコピペ**するか、`stty -f /dev/cu.xxxx 115200 raw` の後に `cat` してください。

---

## 数字の読み方

| 列 | 意味 |
|----|------|
| `addr` | ボードのアドレス(10/11/12/13) |
| `bar` | 何小節目か(1ずつ増えればOK。飛んだら取りこぼし) |
| `interval_us` | 直前のSYNCから実際に何µsだったか |
| **`drift_us`** | **ズレ(主役)。単位はµs。0に近いほど良い** |

- 単位は **µs(マイクロ秒)**。1000µs=1ms、1,000,000µs=1秒。
- 「+」=遅れ気味 / 「−」=早すぎ気味。

**ひと目でわかる目安(`drift_us` 1個の値):**

| `drift_us` | = | 体感 |
|-----------:|---|------|
| 50 | 0.05 ms | ほぼズレなし 🟢 |
| 500 | 0.5 ms | 良好 🟢 |
| 2000 | 2 ms | まだOK 🟡 |
| 20000 | 20 ms | ここから人が「ズレてる」と感じ始める 🔴 |
| 2000000 | 2 秒(=1小節まるごと) | SYNC取りこぼし ⚠️ |

→ ざっくり ms にしたいなら **数字を1000で割る**(`drift_us=350` → 0.35ms)。

---

## 望ましい結果のめやす(合否判定)

1行ごとの感覚は上の「ひと目でわかる目安」表のとおり。ここでは**録ったデータ全体でまとめて判定**するときの基準を示す。見るのは主に **ばらつき(標準偏差)・最大・取りこぼし**。平均(バイアス)は小さくて安定なら問題なし(毎小節リセットされ累積しないため)。

| 指標 | 🟢 理想 | 🟡 許容 | 🔴 要対策 |
|------|---------|---------|-----------|
| ばらつき(標準偏差) | < 約500µs | < 約2ms | 数ms以上で常時暴れる |
| 最大の \|drift\|(取りこぼし除く) | < 約1〜2ms | < 約10ms | > 約20ms |
| 取りこぼし(`+2,000,000`付近 / `bar`飛び) | 0 | ごく稀 | 頻発 |

- **参考**:人が合奏のズレを感じ始めるのは概ね10〜30ms以上。設計書の強制スナップ閾値も50ms。なので**±数ms以内なら聴感上は十分タイト**。
- **ノイズ床**:たまに±1ms前後の単発スパイクが出るのは `micros()` を割り込み内で読む既知の癖で、実際の同期ズレではない(無視可)。
- 4台それぞれで測り、**全部が小さく似た範囲**なら合奏もタイト。1台だけ大きければそれが弱点。

---

## 🔴 ダメなとき(🔴判定)の対処

- **ばらつき大 / 不安定**:
  - I2C配線を短く / プルアップ(4.7kΩ) / **GNDを全台共通**にする
  - 基板のクロックを確認(**水晶 > セラロック**。セラロック基板はドリフト大)
- **取りこぼし(`+2,000,000` / `bar`飛び)が出る**:
  - SYNCが届いていない = 通信信頼性の問題(配線・プルアップ・バス長・ノイズ)
  - 既知の課題:master は START/CONFIG/SYNC を**再送しない**(取りこぼしに無防備)
  - 改善案:master 側で SYNC/START の再送、I2C バス復旧処理を追加
- **1台だけ大きい**:その楽器の配線 / 基板 / `MY_I2C_ADDRESS` を疑う
- **もっと良くしたい**:
  - **PLL補正**を入れる(ばらつきを平滑化＋取りこぼし耐性)
  - **I2Cゼネラルコール(一斉同報)**でドラム最遅(配信順スキュー ~1.5ms)を解消

---

## データを集めて集計する(任意)

**Mac の例**(シリアルモニタは閉じる。ポート名は「ツール>ポート」で確認):
```
stty -f /dev/cu.usbmodemXXXX 115200 raw
cat /dev/cu.usbmodemXXXX > drum_drift.csv      # 止めるのは Ctrl+C、ボードごと別名で
```

**かんたん集計(Python)**:
```python
import csv, statistics
vals = []
with open("drum_drift.csv") as f:
    for row in csv.reader(f):
        if len(row) == 4 and row[3].lstrip("-").isdigit():
            d = int(row[3])
            if abs(d) < 1_000_000:          # 取りこぼし(+2000000付近)は除外
                vals.append(d)
print("件数 :", len(vals))
print("平均 :", round(statistics.mean(vals), 1), "us")
print("標準偏差:", round(statistics.pstdev(vals), 1), "us")
print("最大 :", max(vals), " 最小:", min(vals), "us")
```
この「平均・標準偏差・最大」が **PLLなしのベースライン**になります。

---

## ⚠️ 測り終わったら戻す
このスケッチは**音を鳴らさない測定専用**です。終わったら各スレーブを**本番ファーム**(`flute/arduino/flute_slave/` など)に焼き戻してください。

## 困ったとき
| 症状 | 見るところ |
|------|-----------|
| 何も出ない | ボーレート115200か / masterが動いてるか / 配線(特に**GND共通**)・プルアップ |
| 文字化け | 保存方法の速度設定。`cat`は`stty`で115200指定、またはモニタからコピペ |
| driftがいつも巨大 | SYNCがほぼ届いていない。I2C配線・アドレス設定 |
| 1台だけ出ない | そのボードの `MY_I2C_ADDRESS`・配線 |

---

## このテストは本番にどれくらい近いか
- SYNC受信のタイミング測定は**本番と同一経路**(同じI2C・同じ割り込み`receiveEvent`・同じ`micros()`基準・実物のmaster)。**同期を決める部分はそのまま本番**。
- 違いは「音符の生成・Serial送信をしない」点だけ。drift時刻は割り込み内で取るので、本番でも値はほぼ同じ。
- **注意**:本番はメインループが音符処理で忙しいぶん、割り込み応答がごく僅か(µs級)遅れる可能性 → 実ジッタは測定値より少しだけ大きいことがある。
- 測れないのは「楽器間の絶対スキュー」と「Processing合成〜実音までの遅延」(別途:監視Arduino/オシロ)。

## 測れる範囲 / 測れない範囲
- ✅ 各楽器の「小節ごとのタイミング誤差(ジッタ＋master基準のクロックずれ)」。同期が安定しているか分かる。
- ❌ 楽器どうしの**絶対スキュー**(例:フルートとドラムが実際に何msズレて鳴り出したか)。共通クロックが要るので別途(監視Arduino/オシロ)。

## 動作確認
波括弧/丸括弧の対応は確認済み。実コンパイルは Arduino IDE で要確認(`arduino-cli` 未導入環境のため)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
